### PR TITLE
Remove GitHub API Call from footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Link from "next/link";
 import { FaHeart } from "react-icons/fa6";
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,35 +1,8 @@
-"use client";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Link from "next/link";
 import { FaHeart } from "react-icons/fa6";
 
 const Footer = () => {
-  const [lastUpdated, setLastUpdated] = useState("");
-
-  useEffect(() => {
-    const fetchLastCommitDate = async () => {
-      try {
-        // Using your GitHub repo details:
-        const response = await fetch("https://api.github.com/repos/rice-apps/bunkmate-but-better/commits?per_page=1");
-        const data = await response.json();
-        if (data && data.length > 0) {
-          const commitDate = data[0].commit.committer.date;
-          const formattedDate = new Date(commitDate).toLocaleDateString("en-US", {
-            month: "long",
-            day: "numeric",
-            year: "numeric",
-          });
-          setLastUpdated(formattedDate);
-          console.log("Successfully updated commit date");
-        }
-      } catch (error) {
-        console.error("Error fetching last commit date:", error);
-      }
-    };
-
-    fetchLastCommitDate();
-  }, []);
-
   return (
     <footer className="bottom-0 w-full mt-auto p-4 text-center text-gray-600 z-50">
       Made with{" "}
@@ -38,14 +11,14 @@ const Footer = () => {
       <Link href="https://riceapps.org/" className="hover:underline text-orange-600">
         RiceApps.
       </Link>{" "}
-      {lastUpdated ? (
+      {process.env.LAST_UPDATED_AT ? (
         <a
           href="https://github.com/rice-apps/bunkmate-but-better"
           target="_blank"
           rel="noopener noreferrer"
           className="underline"
         >
-          Last updated on {lastUpdated}.
+          Last updated on {new Date(process.env.LAST_UPDATED_AT).toLocaleDateString()}
         </a>
       ) : (
         "Loading last updated date..."

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "LAST_UPDATED_AT=$(date -u +%FT%TZ) next build",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
This commit inlines a build environment variable (representing the time when a build occurs) and embeds it in the last updated time for the footer, optimizing out a network call to Github's API which may be incurred each time a page loads.